### PR TITLE
Prevent "NULL pointer to instance" errors when drinking from wells and ponds

### DIFF
--- a/scripts/4_world/entities/manbase/PlayerBase.c
+++ b/scripts/4_world/entities/manbase/PlayerBase.c
@@ -812,16 +812,19 @@ modded class PlayerBase
 	// Adds/removes energy based on consumption item
 	override bool Consume(ItemBase source, float amount, EConsumeType consume_type)
 	{
-		EnergyDrink drink = GetZenSleepConfig().GetEnergyDrink(source.GetType());
-		if (drink.ItemType != "")
+		if (source)
 		{
-			float percent = amount / source.GetQuantityMax();
-			float replenish = (float)MAX_TIREDNESS * (((float)drink.EnergyGained * percent) / 100);
-			InsertAgent(ZenSleep_Agents.TIREDNESS, replenish);
-
-			if (GetZenSleepConfig().DebugOn)
+			EnergyDrink drink = GetZenSleepConfig().GetEnergyDrink(source.GetType());
+			if (drink.ItemType != "")
 			{
-				ZS_SendMessage("Giving energy: " + replenish);
+				float percent = amount / source.GetQuantityMax();
+				float replenish = (float)MAX_TIREDNESS * (((float)drink.EnergyGained * percent) / 100);
+				InsertAgent(ZenSleep_Agents.TIREDNESS, replenish);
+
+				if (GetZenSleepConfig().DebugOn)
+				{
+					ZS_SendMessage("Giving energy: " + replenish);
+				}
 			}
 		}
 


### PR DESCRIPTION
@ZenarchistCode For your consideration...

This change fixes "NULL pointer to instance" errors that are repeatedly emitted when players drink from wells and ponds:

```
SCRIPT    (E): NULL pointer to instance
Class:      'SurvivorBase'
Entity name:'[REDACTED]' id:3038327
Function: 'Consume'
Stack trace:
ZenSleep/scripts/4_world/entities\manbase\playerbase.c:815
scripts/4_World/classes\useractionscomponent\actions\continuous\actiondrinkwellcontinuous.c:66
scripts/4_World/classes\useractionscomponent\actions\actioncontinuousbase.c:216
scripts/4_World/classes\useractionscomponent\actioncomponents\cacontinuousbase.c:12
scripts/4_World/classes\useractionscomponent\actioncomponents\cacontinuousrepeat.c:46
scripts/4_World/classes\useractionscomponent\animatedactionbase.c:66
scripts/4_World/classes\useractionscomponent\animatedactionbase.c:363
scripts/4_World/classes\useractionscomponent\actions\actioncontinuousbase.c:28
```

There is no associated `source` when drinking from wells and ponds, so this change bypasses the energy drink check when `source` is `null`.