### PR TITLE
Add DefineZenSleep.c to script modules

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -56,6 +56,7 @@ class CfgMods
 				value="";
 				files[]=
 				{
+					"ZenSleep/scripts/common",
 					"ZenSleep/scripts/3_game"
 				};
 			};
@@ -64,6 +65,7 @@ class CfgMods
 				value="";
 				files[]=
 				{
+					"ZenSleep/scripts/common",
 					"ZenSleep/scripts/4_world"
 				};
 			};
@@ -72,6 +74,7 @@ class CfgMods
 				value="";
 				files[]=
 				{
+					"ZenSleep/scripts/common",
 					"ZenSleep/scripts/5_mission"
 				};
 			};


### PR DESCRIPTION
@ZenarchistCode For your consideration...

This change adds the `ZenSleep/scripts/common` directory to each of the script modules so that `DefineZenSleep.c` is loaded by the game. This enables scripts from other mods to detect when ZenSleep is loaded, e.g.:

```cpp
#ifdef ZenSleep
    Print("ZenSleep detected!");
#else
    Print("Did not find ZenSleep");
#endif
```